### PR TITLE
Player tweak

### DIFF
--- a/loot/game.cpp
+++ b/loot/game.cpp
@@ -66,6 +66,7 @@ void Game::step(void)
       playerStep();
       render->step();
       render->draw();
+      player->resetMoved();
 
       if(ab->isPushed(BTN_A))
         ab->setState(stateBattle);
@@ -88,7 +89,7 @@ void Game::step(void)
 
 void Game::playerStep(void) //Here just for testing reasons, will be relocated soon
 {
-  Direction dir = player->dir;
+  Direction dir = player->getDirection();
 
   if(ab->isPushed(BTN_L))
     dir = rotateLeft(dir);

--- a/loot/player.cpp
+++ b/loot/player.cpp
@@ -18,11 +18,26 @@ void Player::init(void)
   sp = 10;
 }
 
+Direction Player::getDirection(void) const
+{
+  return this->dir;
+}
+
 void Player::changeDirection(const Direction direction)
 {
   Direction lastDir = this->dir;
   this->dir = direction;
   this->moved = (this->dir != lastDir);
+}
+
+void Player::resetMoved(void)
+{
+  this->moved = false;
+}
+
+bool Player::hasMoved(void) const
+{
+  return this->moved;
 }
 
 void Player::move(const int8_t distance)

--- a/loot/player.h
+++ b/loot/player.h
@@ -10,11 +10,11 @@ class Player
   private:
     System * ab;
     World * world;
+    bool moved;
+    Direction dir;
     
   public:
-    bool moved;
     int8_t x, y; //needs to be signed so checking negative positions doesn't bug out
-    Direction dir;
     uint8_t hp, sp;
     char name[8];
 
@@ -22,8 +22,14 @@ class Player
     Player(System & ab, World & world);
 
     void init(void);
+    
+    Direction getDirection(void) const;
     void changeDirection(const Direction direction);
+    
+    bool hasMoved(void) const;
+    void resetMoved(void);
     void move(const int8_t distance);
+    
     void jump(const uint8_t x, const uint8_t y);
     void step(void);
 };

--- a/loot/render.cpp
+++ b/loot/render.cpp
@@ -81,10 +81,9 @@ void Render::calculateView(const int8_t x, const int8_t y, const Direction dir)
 
 void Render::step(void)
 {
-  if(player->moved) //only recalculate on movement
+  if(player->hasMoved()) //only recalculate on movement
    {
-     calculateView(player->x, player->y, player->dir);
-     player->moved = false;
+     calculateView(player->x, player->y, player->getDirection());
    }
 }
 
@@ -163,7 +162,7 @@ void Render::drawView(void)
   ab->drawRect(0, 0, 64, 64, 1);
 
   ab->setCursor(4, 4);
-  switch(player->dir)
+  switch(getDirection())
   {
     case Direction::East: { ab->print(F("EAST")); break; }
     case Direction::South: { ab->print(F("SOUTH")); break; }
@@ -171,7 +170,7 @@ void Render::drawView(void)
     case Direction::North: {ab->print(F("NORTH")); break; }
     default: { ab->print(F("Wat")); break; }
   }
-  //printf(" Direction: %u", player->dir);
+  //printf(" Direction: %u", getDirection());
 }
 
 void Render::drawMap(void)
@@ -191,7 +190,7 @@ void Render::drawMap(void)
     uint8_t x2 = x1, y2 = y1;
     uint8_t x3 = x1, y3 = y1;
     
-    switch(player->dir)
+    switch(getDirection())
     {
       case Direction::East:
       {

--- a/loot/render.cpp
+++ b/loot/render.cpp
@@ -162,7 +162,7 @@ void Render::drawView(void)
   ab->drawRect(0, 0, 64, 64, 1);
 
   ab->setCursor(4, 4);
-  switch(getDirection())
+  switch(player->getDirection())
   {
     case Direction::East: { ab->print(F("EAST")); break; }
     case Direction::South: { ab->print(F("SOUTH")); break; }

--- a/loot/render.cpp
+++ b/loot/render.cpp
@@ -190,7 +190,7 @@ void Render::drawMap(void)
     uint8_t x2 = x1, y2 = y1;
     uint8_t x3 = x1, y3 = y1;
     
-    switch(getDirection())
+    switch(player->getDirection())
     {
       case Direction::East:
       {


### PR DESCRIPTION
Added 3 new functions and hid two fields in player

Before:

> Sketch uses 16,936 bytes (59%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,709 bytes (66%) of dynamic memory, leaving 851 bytes for local variables. Maximum is 2,560 bytes.

After:

> Sketch uses 16,966 bytes (59%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,709 bytes (66%) of dynamic memory, leaving 851 bytes for local variables. Maximum is 2,560 bytes.

30 bytes added, proving the compiler isn't optimising properly or at least can't inline when the definition is in the cpp file.
