### PR TITLE
Button update

### DIFF
--- a/loot/button.h
+++ b/loot/button.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <stdint.h>
+#include "core/core.h"
+
+enum class Button : uint8_t
+{
+	None = 0,
+	Up = (UP_BUTTON),
+	Down = (DOWN_BUTTON),
+	Left = (LEFT_BUTTON),
+	Right = (RIGHT_BUTTON),
+	A = (A_BUTTON),
+	B = (B_BUTTON),
+	All = 
+	(UP_BUTTON) | (DOWN_BUTTON) |
+	(LEFT_BUTTON) | (RIGHT_BUTTON) |
+	(A_BUTTON) | (B_BUTTON)
+};

--- a/loot/game.cpp
+++ b/loot/game.cpp
@@ -6,6 +6,7 @@
 #include "world.h"
 #include "constants.h"
 #include "direction.h"
+#include "button.h"
 
 Game::Game(System & ab, Render & render, Menu & menu, Player & player, World & world)
 {
@@ -68,7 +69,7 @@ void Game::step(void)
       render->draw();
       player->resetMoved();
 
-      if(ab->isPushed(BTN_A))
+      if(ab->isPushed(Button::A))
         ab->setState(stateBattle);
       break;
     }
@@ -80,7 +81,7 @@ void Game::step(void)
       ab->print(F("Battle"));
       ab->setCursor(66,10);
       ab->print(F("goes here!"));
-      if(ab->isPushed(BTN_A))
+      if(ab->isPushed(Button::A))
         ab->setState(stateGame);
       break;
     }
@@ -91,17 +92,17 @@ void Game::playerStep(void) //Here just for testing reasons, will be relocated s
 {
   Direction dir = player->getDirection();
 
-  if(ab->isPushed(BTN_L))
+  if(ab->isPushed(Button::Left))
     dir = rotateLeft(dir);
 
-  if(ab->isPushed(BTN_R))
+  if(ab->isPushed(Button::Right))
     dir = rotateRight(dir);
 
   player->changeDirection(dir);
 
-  if(ab->isPushed(BTN_U)) //move 1 step in the looking direction
+  if(ab->isPushed(Button::Up)) //move 1 step in the looking direction
     player->move(1);
 
-  if(ab->isPushed(BTN_D))
+  if(ab->isPushed(Button::Down))
     player->move(-1);
 }

--- a/loot/loot.ino
+++ b/loot/loot.ino
@@ -16,7 +16,7 @@ void setup(void)
 	ab.fillScreen(0);
   	ab.drawSprite(8, 5, imgTitle, 1);
 	ab.display();
-	while(!ab.isPushed(BTN_A))	//keep titlescreen up until a button is pressed
+	while(!ab.isPushed(Button::A))	//keep titlescreen up until a button is pressed
 	{
 		ab.update();
 	}

--- a/loot/menu.cpp
+++ b/loot/menu.cpp
@@ -2,6 +2,7 @@
 #include "constants.h"
 #include "graphics.h"
 #include "system.h"
+#include "button.h"
 
 Menu::Menu(System & ab)
 {
@@ -21,7 +22,7 @@ void Menu::step(void)
 
   if(logoAnim == 0) //if menu is ready
   {
-    if(ab->isPushed(BTN_A))
+    if(ab->isPushed(Button::A))
     {
       switch(page)
       {
@@ -49,12 +50,12 @@ void Menu::step(void)
       }
     }
 
-    if(ab->isPushed(BTN_U))
+    if(ab->isPushed(Button::Up))
     {
       --select;
     }
 
-    if(ab->isPushed(BTN_D))
+    if(ab->isPushed(Button::Down))
     {
       ++select;
     }

--- a/loot/system.h
+++ b/loot/system.h
@@ -1,20 +1,11 @@
 #pragma once
 
-#include "core/core.h"
 #include "arduboy.h"
 #include "constants.h"
+#include "button.h"
 
 #define SCREEN_WIDTH  (WIDTH)
 #define SCREEN_HEIGHT (HEIGHT)
-
-// IMPORTANT: These change value depending whether you're compiling for Arduboy 10 or the Devkit.
-// Please remember to define ARDUBOY_10 or AB_DEVKIT in your ino file.
-#define BTN_U (UP_BUTTON)
-#define BTN_D (DOWN_BUTTON)
-#define BTN_L (LEFT_BUTTON)
-#define BTN_R (RIGHT_BUTTON)
-#define BTN_A (A_BUTTON)
-#define BTN_B (B_BUTTON)
 
 class System : public Arduboy
 {
@@ -51,21 +42,21 @@ class System : public Arduboy
     // if(arduboy.pressed(B_BUTTON)) { nowInput |= BTN_B; }
   }
 
-  bool isPressed(const uint8_t button) const
+  bool isPressed(const Button button) const
   {
-     return ((this->nowInput & button) != 0);
+     return ((this->nowInput & static_cast<uint8_t>(button)) != 0);
   }
 
-  bool isPushed(const uint8_t button) const
+  bool isPushed(const Button button) const
   {
     // If pressed this frame, but not last frame
-    return ((this->nowInput & button) != 0) && ((this->prevInput & button) == 0);
+    return ((this->nowInput & static_cast<uint8_t>(button)) != 0) && ((this->prevInput & static_cast<uint8_t>(button)) == 0);
   }
 
-  bool isReleased(const uint8_t button) const
+  bool isReleased(const Button button) const
   {
     // If released in the last frame
-    return ((this->prevInput & button) != 0) && ((this->nowInput & button) == 0);
+    return ((this->prevInput & static_cast<uint8_t>(button)) != 0) && ((this->nowInput & static_cast<uint8_t>(button)) == 0);
   }
 
   void drawSprite(int8_t x, int8_t y, const byte* bitmap, byte c) {


### PR DESCRIPTION
Got rid of the nasty defines in exchange for a nice strongly typed enum class.
The under the hood stuff abuses static_cast so the code is effectively the same as it was before, but only internally. Anything using system now has to use the strongly typed enum which enforces only being able to check one button at a time and means that it's more difficult to pass an invalid Button value (i.e. one would have to abuse casting to do so).

Before:

> Sketch uses 17,168 bytes (59%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,709 bytes (66%) of dynamic memory, leaving 851 bytes for local variables. Maximum is 2,560 bytes.

After:

> Sketch uses 17,168 bytes (59%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,709 bytes (66%) of dynamic memory, leaving 851 bytes for local variables. Maximum is 2,560 bytes.

Net change: 0 bytes
