### PR TITLE
Shaved 18 bytes off for the fun of it

### DIFF
--- a/loot/system.h
+++ b/loot/system.h
@@ -59,32 +59,29 @@ class System : public Arduboy
     return ((this->prevInput & static_cast<uint8_t>(button)) != 0) && ((this->nowInput & static_cast<uint8_t>(button)) == 0);
   }
 
-  void drawSprite(int8_t x, int8_t y, const byte* bitmap, byte c) 
+  void drawSprite(const int8_t x, const int8_t y, const byte* bitmap, const byte c) 
   {
     this->drawBitmap(x ,y , bitmap+2, pgm_read_byte(bitmap), pgm_read_byte(bitmap+1), c);
   }
 
-  void drawSpriteMasked(int8_t x,int8_t y, const byte* bitmap, const byte* mask)
+  void drawSpriteMasked(const int8_t x, const int8_t y, const byte* bitmap, const byte* mask)
   {
     this->drawBitmap(x, y, mask+2, pgm_read_byte(bitmap), pgm_read_byte(bitmap+1),0);
     this->drawBitmap(x, y, bitmap+2, pgm_read_byte(bitmap), pgm_read_byte(bitmap+1),1);
   }
 
-  void drawSpriteCentered(int8_t x, int8_t y, const byte* bitmap, byte c)
+  void drawSpriteCentered(const int8_t x, const int8_t y, const byte* bitmap, const byte c)
   {  
-    int8_t w = pgm_read_byte(bitmap);
-    int8_t h = pgm_read_byte(bitmap+1);
-    this->drawBitmap(x-(w/2), y-(h/2), bitmap+2, w, h, c);
+    const int8_t hw = pgm_read_byte(bitmap) / 2;
+    const int8_t hh = pgm_read_byte(bitmap+1) / 2;
+    this->drawSprite(x-hw, y-hh, bitmap+2, c);
   }  
-  void drawSpriteMaskedCentered(int8_t x, int8_t y, const byte* bitmap, const byte* mask)
+  void drawSpriteMaskedCentered(const int8_t x, const int8_t y, const byte* bitmap, const byte* mask)
   {  
-    int8_t w,h;
-    w = pgm_read_byte(bitmap);
-    h = pgm_read_byte(bitmap+1);
-    x -= w/2;
-    y -= h/2;
-    this->drawBitmap(x, y, mask+2, w, h, 0);
-    this->drawBitmap(x, y, bitmap+2, w, h, 1);
+    const int8_t hw = pgm_read_byte(bitmap) / 2;
+    const int8_t hh = pgm_read_byte(bitmap+1) / 2;
+    this->drawSprite(x - hw, y - hh, mask+2, 0);
+    this->drawSprite(x - hw, y - hh, bitmap+2, 1);
   }
 
   uint8_t getState(void) const

--- a/loot/system.h
+++ b/loot/system.h
@@ -66,8 +66,10 @@ class System : public Arduboy
 
   void drawSpriteMasked(const int8_t x, const int8_t y, const byte* bitmap, const byte* mask)
   {
-    this->drawBitmap(x, y, mask+2, pgm_read_byte(bitmap), pgm_read_byte(bitmap+1),0);
-    this->drawBitmap(x, y, bitmap+2, pgm_read_byte(bitmap), pgm_read_byte(bitmap+1),1);
+    const int8_t w = pgm_read_byte(bitmap);
+    const int8_t h = pgm_read_byte(bitmap+1);    
+    this->drawBitmap(x, y, mask+2, w, h, 0);
+    this->drawBitmap(x, y, bitmap+2, w, h, 1);
   }
 
   void drawSpriteCentered(const int8_t x, const int8_t y, const byte* bitmap, const byte c)


### PR DESCRIPTION
Before:

> Sketch uses 17,202 bytes (59%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,708 bytes (66%) of dynamic memory, leaving 852 bytes for local variables. Maximum is 2,560 bytes.

After:

> Sketch uses 17,184 bytes (59%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,708 bytes (66%) of dynamic memory, leaving 852 bytes for local variables. Maximum is 2,560 bytes.
