### PR TITLE
Introduced MenuPage enum class

### DIFF
--- a/loot/menu.cpp
+++ b/loot/menu.cpp
@@ -53,15 +53,13 @@ void Menu::step(void)
 
     if(ab->isPushed(Button::Up))
     {
-      --select;
+      if(select > 0) --select;
     }
 
     if(ab->isPushed(Button::Down))
     {
-      ++select;
+      if(select < 2) ++select;
     }
-
-    select = min(max(select, 0), 2); //seriously, no clamp()?
   }
 }
 

--- a/loot/menu.cpp
+++ b/loot/menu.cpp
@@ -1,4 +1,5 @@
 #include "menu.h"
+#include "menupage.h"
 #include "constants.h"
 #include "graphics.h"
 #include "system.h"
@@ -11,8 +12,8 @@ Menu::Menu(System & ab)
 
 void Menu::init(void)
 {
+  page = MenuPage::Main;
   select = 0;
-  page = 0;
   logoAnim = 64;
 }
 
@@ -26,25 +27,25 @@ void Menu::step(void)
     {
       switch(page)
       {
-        case 0:
+        case MenuPage::Main:
         {
           switch(select)
           {
           case 0: { ab->setState(stateGame); break; }
-          case 1: { page = 2; break; }
-          case 2: { page = 3; select = 2; break; }
+          case 1: { page = MenuPage::Options; break; }
+          case 2: { page = MenuPage::About; select = 2; break; } // This basically equates to if(select == 2) select = 2;
           }
           break;
         }
-        case 2:
+        case MenuPage::Options:
         {
-          page = 0;
+          page = MenuPage::Main;
           select = 1;
           break;
         }
-        case 3:
+        case MenuPage::About:
         {
-          page = 0;
+          page = MenuPage::Main;
           break;
         }
       }
@@ -68,7 +69,7 @@ void Menu::draw(void)
 {
   switch(page)
   {
-    case 0:
+    case MenuPage::Main:
     {
       //logo
       if (logoAnim > 0)
@@ -85,20 +86,23 @@ void Menu::draw(void)
       ab->print(F(">"));
       break;
     }
-    case 1: //Slots
+    // Why leave comments explaining what the numbers are when you can do this:
+    case MenuPage::Slots:
     {
     }
-    case 2: //options
+    case MenuPage::Options:
     {
       ab->setCursor(0, 0);
       ab->print(F("Nothing to see here!"));
       break;
     }
-    case 3: //About
+    case MenuPage::About:
     {
       ab->setCursor(0, 0);
       ab->print(F("Test string!"));
       break;
     }
+    // And the best bit, it's exactly equivalent to what you were doing before,
+    // no memory penalty, no performance penalty, just compiler magic
   }
 }

--- a/loot/menu.h
+++ b/loot/menu.h
@@ -1,13 +1,16 @@
 #pragma once
 #include <stdint.h>
 
+#include "menupage.h"
+
 class System;
 
 class Menu
 {
   private:
     System * ab;
-    int8_t select, page;
+    MenuPage page;
+    int8_t select;
     int8_t logoAnim;  //slides menu up
     
   public:

--- a/loot/menupage.h
+++ b/loot/menupage.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <stdint.h>
+
+enum class MenuPage : uint8_t
+{
+  Main,
+  Slots,
+  Options,
+  About
+};


### PR DESCRIPTION
Before:

> Sketch uses 17,248 bytes (60%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,708 bytes (66%) of dynamic memory, leaving 852 bytes for local variables. Maximum is 2,560 bytes.

After introducing GamePage:

> Sketch uses 17,238 bytes (60%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,708 bytes (66%) of dynamic memory, leaving 852 bytes for local variables. Maximum is 2,560 bytes.

After changing to the new clamping technique:

> Sketch uses 17,224 bytes (60%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,708 bytes (66%) of dynamic memory, leaving 852 bytes for local variables. Maximum is 2,560 bytes.

What's interesting is that it shows the compiler is aware of enum classes and is actually able to somehow optimise them. I was genuinely expecting the first two to be the same, the 10 byte reduction was a big surprise. The 12 byte reduction from the change in clamping method is completely expected, a simple compare and branch will always trump something that has to push arguments to the stack.
