### PR TITLE
Player::move switch cleanup

### DIFF
--- a/loot/player.cpp
+++ b/loot/player.cpp
@@ -44,22 +44,15 @@ void Player::resetMoved(void)
 
 void Player::move(const int8_t distance)
 {
-  int8_t ny, nx;  //calculate direction
+  int8_t ny = 0, nx = 0;
   switch(this->dir)
   {
-    //compiler is bugged, neccesitating doing it like this:
-    case Direction::East: nx = 1;  break;
-    case Direction::South: ny = 1; nx = 0;break;
-    case Direction::West: nx = -1; break;
-    case Direction::North: ny = -1; nx = 0; break;
-    /*
-    case Direction::East: nx = 1; break;
-    case Direction::South: ny = 1; break;
-    case Direction::West: nx = -1; break;
-    case Direction::North: ny = -1; break;
-    */
+    case Direction::East: nx = distance;  break;
+    case Direction::South: ny = distance;break;
+    case Direction::West: nx = -distance; break;
+    case Direction::North: ny = -distance; break;
   }
-  this->jump( this->x + (nx*distance), this->y + (ny*distance));
+  this->jump( this->x + nx, this->y + ny);
   this->battleSteps += abs(distance);
 }
 

--- a/loot/player.cpp
+++ b/loot/player.cpp
@@ -52,7 +52,7 @@ void Player::move(const int8_t distance)
     case Direction::West: nx = -distance; break;
     case Direction::North: ny = -distance; break;
   }
-  this->jump( this->x + nx, this->y + ny);
+  this->jump(this->x + nx, this->y + ny);
   this->battleSteps += abs(distance);
 }
 


### PR DESCRIPTION
**Purpose:**
This makes the switch in `Player::move` clearer and more consistent whilst keeping the logic effectively the same.

**Before:**

> Sketch uses 18,294 bytes (63%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,653 bytes (64%) of dynamic memory, leaving 907 bytes for local variables. Maximum is 2,560 bytes.

**After:**

> Sketch uses 18,294 bytes (63%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,653 bytes (64%) of dynamic memory, leaving 907 bytes for local variables. Maximum is 2,560 bytes.

**Change:**
Program memory: +0
Global memory: +0
