### PR TITLE
Corrected spelling to centred

### DIFF
--- a/loot/loot.ino
+++ b/loot/loot.ino
@@ -24,7 +24,7 @@ void setup(void)
 	Serial.begin(9600);
 	Serial.println(F("Start!"));
 	ab.fillScreen(0);
-  	ab.drawSpriteCentered(64, 32, imgTitle, 1);
+  	ab.drawSpriteCentred(64, 32, imgTitle, 1);
 	ab.display();
 	while(!ab.isPushed(Button::A))	//keep titlescreen up until a button is pressed
 	{

--- a/loot/menu.cpp
+++ b/loot/menu.cpp
@@ -71,7 +71,7 @@ void Menu::draw(void)
     {
       //logo
       if (logoAnim > 0)
-        ab->drawSpriteCentered(64, 32 - (64 - logoAnim), imgTitle, 1);
+        ab->drawSpriteCentred(64, 32 - (64 - logoAnim), imgTitle, 1);
       //menu text
       ab->setCursor(16, logoAnim + 8);
       ab->print(F("Play"));

--- a/loot/render.cpp
+++ b/loot/render.cpp
@@ -179,7 +179,7 @@ void Render::drawView(void)
     case Direction::South: { image = imgCompassS; break; }
     case Direction::West:  { image = imgCompassW; break; }
   }
-  ab->drawSpriteCentered(32,6,image,1);
+  ab->drawSpriteCentred(32,6,image,1);
 
   //printf(" Direction: %u", player->getDirection());
 }

--- a/loot/system.h
+++ b/loot/system.h
@@ -70,14 +70,14 @@ class System : public Arduboy
     this->drawBitmap(x, y, bitmap+2, pgm_read_byte(bitmap), pgm_read_byte(bitmap+1),1);
   }
   
-  void drawSpriteCentered(int8_t x, int8_t y, const uint8_t* bitmap, uint8_t c)
+  void drawSpriteCentred(int8_t x, int8_t y, const uint8_t* bitmap, uint8_t c)
   {  
     int8_t w = pgm_read_byte(bitmap);
     int8_t h = pgm_read_byte(bitmap+1);
     this->drawBitmap(x-(w/2), y-(h/2), bitmap+2, w, h, c);
   }  
 
-  void drawSpriteMaskedCentered(int8_t x, int8_t y, const uint8_t* bitmap, const uint8_t* mask)
+  void drawSpriteMaskedCentred(int8_t x, int8_t y, const uint8_t* bitmap, const uint8_t* mask)
   {  
     int8_t w,h;
     w = pgm_read_byte(bitmap);


### PR DESCRIPTION
**Purpose:**
Corrected spelling to centred in `System::drawSpriteCentred` and `System::drawSpriteMaskedCentred`

**Before:**

> Sketch uses 18,294 bytes (63%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,653 bytes (64%) of dynamic memory, leaving 907 bytes for local variables. 
> Maximum is 2,560 bytes.

**After:**

> Sketch uses 18,294 bytes (63%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,653 bytes (64%) of dynamic memory, leaving 907 bytes for local variables. 
> Maximum is 2,560 bytes.

**Change:**
Program memory: +0
Global memory: +0
