### PR TITLE
Cleaned up the sprite drawing functions

### DIFF
--- a/loot/system.h
+++ b/loot/system.h
@@ -72,15 +72,15 @@ class System : public Arduboy
   
   void drawSpriteCentred(const int8_t x, const int8_t y, const uint8_t * bitmap, const uint8_t colour)
   {  
-    int8_t w = pgm_read_byte(bitmap + 0);
-    int8_t h = pgm_read_byte(bitmap + 1);
+    const int8_t w = pgm_read_byte(bitmap + 0);
+    const int8_t h = pgm_read_byte(bitmap + 1);
     this->drawBitmap(x - (w / 2), y - (h / 2), bitmap + 2, w, h, colour);
   }  
 
   void drawSpriteMaskedCentered(const int8_t x, const int8_t y, const uint8_t * bitmap, const uint8_t* mask)
   {  
-    int8_t w = pgm_read_byte(bitmap + 0);
-    int8_t h = pgm_read_byte(bitmap + 1);
+    const int8_t w = pgm_read_byte(bitmap + 0);
+    const int8_t h = pgm_read_byte(bitmap + 1);
     this->drawBitmap(x - (w / 2), y - (h / 2), mask + 2, w, h, 0);
     this->drawBitmap(x - (w / 2), y - (h / 2), bitmap + 2, w, h, 1);
   }

--- a/loot/system.h
+++ b/loot/system.h
@@ -59,33 +59,30 @@ class System : public Arduboy
     return ((this->prevInput & static_cast<uint8_t>(button)) != 0) && ((this->nowInput & static_cast<uint8_t>(button)) == 0);
   }
 
-  void drawSprite(int8_t x, int8_t y, const uint8_t* bitmap, uint8_t c) 
+  void drawSprite(const int8_t x, const int8_t y, const uint8_t * bitmap, const uint8_t colour) 
   {
-    this->drawBitmap(x ,y , bitmap+2, pgm_read_byte(bitmap), pgm_read_byte(bitmap+1), c);
+    this->drawBitmap(x ,y , bitmap + 2, pgm_read_byte(bitmap + 0), pgm_read_byte(bitmap + 1), colour);
   }
 
-  void drawSpriteMasked(int8_t x,int8_t y, const uint8_t* bitmap, const uint8_t* mask)
+  void drawSpriteMasked(const int8_t x, const int8_t y, const uint8_t * bitmap, const uint8_t* mask)
   {
-    this->drawBitmap(x, y, mask+2, pgm_read_byte(bitmap), pgm_read_byte(bitmap+1),0);
-    this->drawBitmap(x, y, bitmap+2, pgm_read_byte(bitmap), pgm_read_byte(bitmap+1),1);
+    this->drawBitmap(x, y, mask + 2, pgm_read_byte(bitmap + 0), pgm_read_byte(bitmap + 1), 0);
+    this->drawBitmap(x, y, bitmap + 2, pgm_read_byte(bitmap + 0), pgm_read_byte(bitmap + 1), 1);
   }
   
-  void drawSpriteCentred(int8_t x, int8_t y, const uint8_t* bitmap, uint8_t c)
+  void drawSpriteCentred(const int8_t x, const int8_t y, const uint8_t * bitmap, const uint8_t colour)
   {  
-    int8_t w = pgm_read_byte(bitmap);
-    int8_t h = pgm_read_byte(bitmap+1);
-    this->drawBitmap(x-(w/2), y-(h/2), bitmap+2, w, h, c);
+    int8_t w = pgm_read_byte(bitmap + 0);
+    int8_t h = pgm_read_byte(bitmap + 1);
+    this->drawBitmap(x - (w / 2), y - (h / 2), bitmap + 2, w, h, colour);
   }  
 
-  void drawSpriteMaskedCentred(int8_t x, int8_t y, const uint8_t* bitmap, const uint8_t* mask)
+  void drawSpriteMaskedCentered(const int8_t x, const int8_t y, const uint8_t * bitmap, const uint8_t* mask)
   {  
-    int8_t w,h;
-    w = pgm_read_byte(bitmap);
-    h = pgm_read_byte(bitmap+1);
-    x -= w/2;
-    y -= h/2;
-    this->drawBitmap(x, y, mask+2, w, h, 0);
-    this->drawBitmap(x, y, bitmap+2, w, h, 1);
+    int8_t w = pgm_read_byte(bitmap + 0);
+    int8_t h = pgm_read_byte(bitmap + 1);
+    this->drawBitmap(x - (w / 2), y - (h / 2), mask + 2, w, h, 0);
+    this->drawBitmap(x - (w / 2), y - (h / 2), bitmap + 2, w, h, 1);
   }
 
   uint8_t getState(void) const


### PR DESCRIPTION
**Purpose:**
Made the sprite drawing functions clearer and easier to read. 
Let the compiler figure out the optimisations.

**Before:**

> Sketch uses 18,294 bytes (63%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,653 bytes (64%) of dynamic memory, leaving 907 bytes for local variables. Maximum is 2,560 bytes.

**After:**

> Sketch uses 18,294 bytes (63%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,653 bytes (64%) of dynamic memory, leaving 907 bytes for local variables. Maximum is 2,560 bytes.

**Change:**
Program memory: +0
Global memory: +0

**Footnotes:**
Marked a number of the variables as const to help the compiler deduce optimisations.
In particular marking `w`, `h`, `x` and `y` as const means that the compiler can easily prove that the expressions `x - (w / 2)` and `y - (h / 2)` can be computed once at the begining of the function and cached.
Note that it can achieve this without the `const` declarations by showing that all the variables are assigned to exactly once, but the `const` declarations make this deduction implicit so the compiler does not have to analyse the whole function to know that the variables do not change after assignment.
