### PR TITLE
Utilising screen size constants

### DIFF
--- a/loot/battle.cpp
+++ b/loot/battle.cpp
@@ -17,7 +17,7 @@ void Battle::step(void)
 
 void Battle::draw(void)
 {
-	ab->setCursor(64,0);
+	ab->setCursor(System::ScreenCentreX, 0);
 	ab->print(F("BATTLE!"));
 }
 

--- a/loot/loot.ino
+++ b/loot/loot.ino
@@ -24,7 +24,7 @@ void setup(void)
 	Serial.begin(9600);
 	Serial.println(F("Start!"));
 	ab.fillScreen(0);
-  	ab.drawSpriteCentred(64, 32, imgTitle, 1);
+  	ab.drawSpriteCentred(System::ScreenCentreX, System::ScreenCentreY, imgTitle, 1);
 	ab.display();
 	while(!ab.isPushed(Button::A))	//keep titlescreen up until a button is pressed
 	{

--- a/loot/menu.cpp
+++ b/loot/menu.cpp
@@ -14,7 +14,7 @@ void Menu::init(void)
 {
   page = MenuPage::Main;
   select = 0;
-  logoAnim = 64;
+  logoAnim = System::ScreenHeight;
 }
 
 void Menu::step(void)
@@ -71,7 +71,7 @@ void Menu::draw(void)
     {
       //logo
       if (logoAnim > 0)
-        ab->drawSpriteCentred(64, 32 - (64 - logoAnim), imgTitle, 1);
+        ab->drawSpriteCentred(System::ScreenCentreX, System::ScreenCentreY - (System::ScreenHeight - logoAnim), imgTitle, 1);
       //menu text
       ab->setCursor(16, logoAnim + 8);
       ab->print(F("Play"));

--- a/loot/render.cpp
+++ b/loot/render.cpp
@@ -8,7 +8,7 @@
 #include "itemtype.h"
 
 
-Render::Render(System & ab,World & world, Player & player)
+Render::Render(System & ab, World & world, Player & player)
 {
   this->ab = &ab;
   this->world = &world;
@@ -244,10 +244,10 @@ void Render::drawMap(void)
 
 void Render::drawStats(void)
 {
-  ab->setCursor(66, 2);
+  ab->setCursor(System::ScreenCentreX + 2, 2);
   ab->print(F("HP : "));
-  ab->setCursor(66, 10);
+  ab->setCursor(System::ScreenCentreX + 2, 10);
   ab->print(F("SP : "));
-  ab->setCursor(66, 18);
+  ab->setCursor(System::ScreenCentreX + 2, 18);
   ab->print(F("G  : "));
 }

--- a/loot/render.cpp
+++ b/loot/render.cpp
@@ -168,8 +168,8 @@ void Render::drawView(void)
       leftBack += backSize;
     }
   }
-  ab->fillRect(64, 0, 16, 64, 0);  //hide any leaky drawing
-  ab->drawRect(0, 0, 64, 64, 1);
+  ab->fillRect(System::ScreenCentreX, 0, 16, System::ScreenHeight, 0);  //hide any leaky drawing
+  ab->drawRect(0, 0, System::ScreenWidth / 2, System::ScreenHeight, 1);
 
   const uint8_t * image;
   switch(player->getDirection())
@@ -238,8 +238,8 @@ void Render::drawMap(void)
   }
 
   //outlines the map
-  ab->drawLine(offsetx + 64, 0, offsetx + 64, 63, 1);
-  ab->drawLine(offsetx, 63, offsetx + 64, 63, 1);
+  ab->drawLine(offsetx + (System::ScreenWidth / 2), 0, offsetx + (System::ScreenWidth / 2), System::ScreenHeight - 1, 1);
+  ab->drawLine(offsetx, System::ScreenHeight - 1, offsetx + (System::ScreenWidth / 2), System::ScreenHeight - 1, 1);
 }
 
 void Render::drawStats(void)


### PR DESCRIPTION
**Purpose:**
Put the new screen size constants into action to make several cases of drawing code easier to understand.

**Before:**

> Sketch uses 18,294 bytes (63%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,653 bytes (64%) of dynamic memory, leaving 907 bytes for local variables. Maximum is 2,560 bytes.

**After:**

> Sketch uses 18,294 bytes (63%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,653 bytes (64%) of dynamic memory, leaving 907 bytes for local variables. Maximum is 2,560 bytes.

**Change:**
Program memory: +0
Global memory: +0
