### PR TITLE
Reduced code size by 50 bytes

### DIFF
--- a/loot/world.cpp
+++ b/loot/world.cpp
@@ -37,8 +37,8 @@ void World::init(void)
   width = 8;
   height = 8;
 
-  //replace this bit with a progmem loader doodah
-  uint8_t leveldata[64] =
+  // Replace this bit with a progmem loader doodah
+  static const uint8_t leveldata[64] =
   {
     1,1,1,1,1,1,1,1,
     0,0,0,0,0,1,0,0,


### PR DESCRIPTION
**Purpose:**
Made temp world data static to enable further optimisation.

**Before:**

> Sketch uses 18,218 bytes (63%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,653 bytes (64%) of dynamic memory, leaving 907 bytes for local variables. Maximum is 2,560 bytes.

**After:**

> Sketch uses 18,168 bytes (63%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,653 bytes (64%) of dynamic memory, leaving 907 bytes for local variables. Maximum is 2,560 bytes.

**Change:**
Program memory: -50
Global memory: +0
