### PR TITLE
Changed C-style casts to static cast

### DIFF
--- a/loot/player.cpp
+++ b/loot/player.cpp
@@ -93,7 +93,7 @@ void Player::step()
     if (world->hasItem(x,y))
     {
       Serial.print(F("Item! Type : "));
-      Serial.print((uint8_t)world->getItemType(x,y));
+      Serial.print(static_cast<uint8_t>(world->getItemType(x,y)));
       Serial.print(F(" ID : "));
       Serial.println(world->getItemID(x,y));
     }

--- a/loot/world.cpp
+++ b/loot/world.cpp
@@ -51,7 +51,7 @@ void World::init(void)
   };
   for(uint8_t i=0; i<64; ++i)
   {
-    level[i] = (TileType)leveldata[i];
+    level[i] = static_cast<TileType>(leveldata[i]);
   };
   battleTendency = 4;
 


### PR DESCRIPTION
**Purpose:**
Using `static_cast` is better practise and occaisionally more efficient.

**Before:**

> Sketch uses 18,168 bytes (63%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,653 bytes (64%) of dynamic memory, leaving 907 bytes for local variables. Maximum is 2,560 bytes.

**After:**

> Sketch uses 18,168 bytes (63%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,653 bytes (64%) of dynamic memory, leaving 907 bytes for local variables. Maximum is 2,560 bytes.

**Change:**
Program memory: +0
Global memory: +0
