### PR TITLE
Merged two switch statements. Saved 18 bytes

### DIFF
--- a/loot/game.cpp
+++ b/loot/game.cpp
@@ -31,55 +31,36 @@ void Game::load(const bool slot)
 
 void Game::step(void)
 {
-  if (ab->stateChanged())
-  {
-    auto state = ab->getState();
-    switch(state)
+    switch(ab->getState())
     {
-      case GameState::Menu:
-      {
-        menu->init();
-        break;
-      }
-      case GameState::Gameplay:
-      {
-        if (ab->getLastState() == GameState::Menu)
-        {
-          player->init();
-          world->init();
-          break;
-        }
-      }
-      case GameState::Battle:
-      {
-      }
+  		case GameState::Menu:
+  		{
+  			if (ab->stateChanged())
+  			{
+  				menu->init();
+  			}
+  			menu->step();
+  			menu->draw();
+  			break;
+  		}
+  		case GameState::Gameplay:
+  		{
+  			if (ab->getLastState() == GameState::Menu)
+  			{
+  				player->init();
+  				world->init();
+  			}
+  			player->step();
+  			render->step();
+  			render->draw();
+  			player->resetMoved();
+  			break;
+  		}
+  		case GameState::Battle:
+  		{
+  			battle->step();
+  			render->drawView();
+  			battle->draw();
+  		}
     }
-  }
-  ab->stateEndChange();
-
-  switch(ab->getState())
-  {
-    case GameState::Menu:
-    {
-      menu->step();
-      menu->draw();
-      break;
-    }
-    case GameState::Gameplay:
-    {
-      player->step();
-      render->step();
-      render->draw();
-      player->resetMoved();
-      break;
-    }
-    case GameState::Battle:
-    {
-      battle->step();
-
-      render->drawView();
-      battle->draw();
-      break;
-    }
-  }
 }


### PR DESCRIPTION
**Purpose:**
Save 18 bytes.

**Before:**

> Sketch uses 18,156 bytes (63%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,653 bytes (64%) of dynamic memory, leaving 907 bytes for local variables. Maximum is 2,560 bytes.

**After:**

> Sketch uses 18,138 bytes (63%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,653 bytes (64%) of dynamic memory, leaving 907 bytes for local variables. Maximum is 2,560 bytes.

**Change:**
Program memory: -18
Global memory: +0
