### PR TITLE
Fixed accidental removal of ab->stateEndChange()

### DIFF
--- a/loot/game.cpp
+++ b/loot/game.cpp
@@ -38,6 +38,7 @@ void Game::step(void)
   			if (ab->stateChanged())
   			{
   				menu->init();
+  				ab->stateEndChange();
   			}
   			menu->step();
   			menu->draw();
@@ -49,6 +50,7 @@ void Game::step(void)
   			{
   				player->init();
   				world->init();
+  				ab->stateEndChange();
   			}
   			player->step();
   			render->step();


### PR DESCRIPTION
**Purpose:**
Bug fix.

**Before:**

> Sketch uses 18,138 bytes (63%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,653 bytes (64%) of dynamic memory, leaving 907 bytes for local variables. Maximum is 2,560 bytes.

**After:**

> Sketch uses 18,180 bytes (63%) of program storage space. Maximum is 28,672 bytes.
> Global variables use 1,653 bytes (64%) of dynamic memory, leaving 907 bytes for local variables. Maximum is 2,560 bytes.

**Change:**
Program memory: +42
Global memory: +0
